### PR TITLE
Do not cache results from initial query

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "pollster",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/samuelcole/pollster",
   "authors": [
     "Samuel Cole <sam@samuelcole.name>"

--- a/pollster.jquery.json
+++ b/pollster.jquery.json
@@ -2,7 +2,7 @@
   "name": "pollster",
   "title": "Pollster",
   "description": "Ping a url for a specific response.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/samuelcole/pollster",
   "author": {
     "name": "Samuel Cole",

--- a/src/pollster.js
+++ b/src/pollster.js
@@ -58,11 +58,9 @@
       }
     }
 
-    var url = this.url + (this.url.indexOf('?') >= 0 ? '&' : '?') + 'pollster_timestamp=' + new Date().getTime();
-
     //TODO: get rid of this jQuery dependecy
     this.xhr = $.ajax({
-      url: url,
+      url: this.url,
       dataType: 'json',
       type: 'get',
       global: false,

--- a/src/pollster.js
+++ b/src/pollster.js
@@ -58,12 +58,15 @@
       }
     }
 
+    var url = this.url + (this.url.indexOf('?') > 0 ? '&' : '?') + 'pollster_timestamp=' + new Date().getTime();
+
     //TODO: get rid of this jQuery dependecy
     this.xhr = $.ajax({
-      url: this.url,
+      url: url,
       dataType: 'json',
       type: 'get',
       global: false,
+      cache: false,
       success: function (data) {
         stop = _this.finished(data);
         cont();

--- a/src/pollster.js
+++ b/src/pollster.js
@@ -58,7 +58,7 @@
       }
     }
 
-    var url = this.url + (this.url.indexOf('?') > 0 ? '&' : '?') + 'pollster_timestamp=' + new Date().getTime();
+    var url = this.url + (this.url.indexOf('?') >= 0 ? '&' : '?') + 'pollster_timestamp=' + new Date().getTime();
 
     //TODO: get rid of this jQuery dependecy
     this.xhr = $.ajax({


### PR DESCRIPTION
Trying to bust any caching that might be happening on iOS devices pre-iOS7. This adds `{cache: false}`  to the `$.ajax` call which alters the URL to include a timestamp parameter.
